### PR TITLE
Fix Issue #2. Missing variadic type argument in app_logger.LogFatalf

### DIFF
--- a/logger/app_logger.go
+++ b/logger/app_logger.go
@@ -33,5 +33,5 @@ func LogFatal(msg string) {
 }
 
 func LogFatalf(format string, v ...interface{}) {
-	aLogger.Fatalf(format, v)
+	aLogger.Fatalf(format, v...)
 }

--- a/logger/app_logger_test.go
+++ b/logger/app_logger_test.go
@@ -1,0 +1,12 @@
+package logger
+
+import (
+	"testing"
+)
+
+func Test_InitAppLogger(t *testing.T) {
+	err := InitAppLogger("")
+	if err != nil {
+		t.Errorf("expected log horlix.log in current directory, got %v", err)
+	}
+}


### PR DESCRIPTION
### **Description**
The variadic type parameter was missing in LogFatalf function in the logger package. As a result, the fatal error has been thrown every time when the application reaches to the function. Now the change has been made to pass a proper type into aLogger.Fatalf

Fixes #2 